### PR TITLE
Vtrust smoothing

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -178,7 +178,7 @@ class Validator:
         parser.add_argument(
             "--immediate",
             action="store_true",
-            help="Triggers run step immediately. NOT RECOMMENDED FOR PRODUCTION",
+            help="Triggers setting weights immediately. NOT RECOMMENDED FOR PRODUCTION",
         )
         parser.add_argument(
             "--offline",

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -687,6 +687,8 @@ class Validator:
                     bt.logging.debug("Setting weights.")
                     _try_set_weights()
                     bt.logging.debug("Finished setting weights.")
+                    if self.config.immediate:
+                        time.sleep(3600)
                 except asyncio.TimeoutError:
                     bt.logging.error(f"Failed to set weights after {ttl} seconds")
             else:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -680,7 +680,7 @@ class Validator:
                 self.set_weights_last = dt.datetime.now()
                 try:
                     bt.logging.debug("Setting weights.")
-                    asyncio.run(_try_set_weights(), ttl)
+                    utils.run_in_subprocess(_try_set_weights, ttl)
                     bt.logging.debug("Finished setting weights.")
                 except asyncio.TimeoutError:
                     bt.logging.error(f"Failed to set weights after {ttl} seconds")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -468,7 +468,7 @@ class Validator:
         if not self.config.dont_set_weights and not self.config.offline:
             self.weight_thread = threading.Thread(
                 target=self.try_set_weights,
-                args=(300),
+                args=(300,),
                 daemon=True,
             )
             self.weight_thread.start()

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -46,7 +46,6 @@ from datasets import disable_caching
 import traceback
 import threading
 import multiprocessing
-import functools
 from rich.table import Table
 from rich.console import Console
 
@@ -185,12 +184,6 @@ class Validator:
             "--offline",
             action="store_true",
             help="Does not launch a wandb run, does not set weights, does not check that your key is registered.",
-        )
-        parser.add_argument(
-            "--set_weights_delay_minutes",
-            type=int,
-            default=20,
-            help="Period between attempting to set weights",
         )
         parser.add_argument(
             "--model_dir",
@@ -676,7 +669,7 @@ class Validator:
             console = Console()
             console.print(table)
 
-        # Continually loop and set weights every `set_weights_delay_minutes` minutes.
+        # Continually loop and set weights at the 20-minute mark
         while not self.stop_event.is_set():
             current_time = dt.datetime.utcnow()
             minutes = current_time.minute
@@ -1082,8 +1075,6 @@ class Validator:
                     )
                     self.global_step += 1
 
-                #if not self.config.dont_set_weights and not self.config.offline:
-                    #await self.try_set_weights(ttl=300)
                 self.last_epoch = self.metagraph.block.item()
                 self.epoch_step += 1
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -465,6 +465,7 @@ class Validator:
         self.clean_thread.start()
 
         # == Initialize the weight setting thread ==
+        self.set_weights_last = dt.datetime.now()
         if not self.config.dont_set_weights and not self.config.offline:
             self.weight_thread = threading.Thread(
                 target=self.try_set_weights,
@@ -637,7 +638,7 @@ class Validator:
         )
         return new_weights
 
-    async def try_set_weights(self, ttl: int, set_weights_delay_minutes: int):
+    def try_set_weights(self, ttl: int, set_weights_delay_minutes: int):
         async def _try_set_weights():
             try:
                 # Fetch latest metagraph
@@ -675,7 +676,7 @@ class Validator:
             self.set_weights_last = dt.datetime.now()
             try:
                 bt.logging.debug("Setting weights.")
-                await asyncio.wait_for(_try_set_weights(), ttl)
+                asyncio.run(_try_set_weights(), ttl)
                 bt.logging.debug("Finished setting weights.")
             except asyncio.TimeoutError:
                 bt.logging.error(f"Failed to set weights after {ttl} seconds")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -46,6 +46,7 @@ from datasets import disable_caching
 import traceback
 import threading
 import multiprocessing
+import functools
 from rich.table import Table
 from rich.console import Console
 
@@ -680,7 +681,8 @@ class Validator:
                 self.set_weights_last = dt.datetime.now()
                 try:
                     bt.logging.debug("Setting weights.")
-                    utils.run_in_subprocess(_try_set_weights, ttl)
+                    partial = functools.partial(_try_set_weights)
+                    utils.run_in_subprocess(partial, ttl)
                     bt.logging.debug("Finished setting weights.")
                 except asyncio.TimeoutError:
                     bt.logging.error(f"Failed to set weights after {ttl} seconds")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -634,13 +634,16 @@ class Validator:
                     netuid=self.config.netuid,
                     wallet=self.wallet,
                     uids=self.metagraph.uids,
-                    weights=self.weights,
+                    weights=adjusted_weights,
                     wait_for_inclusion=False,
-                    wait_for_finalization=True,
                     version_key=constants.weights_version_key,
                 )
-            except:
-                pass
+                weights_report = {"weights": {}}
+                for uid, score in enumerate(self.weights):
+                    weights_report["weights"][uid] = score
+                bt.logging.debug("weights_report", weights=weights_report)
+            except Exception as e:
+                bt.logging.error(f"failed to set weights {e}")
             ws, ui = self.weights.topk(len(self.weights))
             table = Table(title="All Weights")
             table.add_column("uid", justify="right", style="cyan", no_wrap=True)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -178,7 +178,7 @@ class Validator:
         parser.add_argument(
             "--immediate",
             action="store_true",
-            help="Triggers setting weights immediately. NOT RECOMMENDED FOR PRODUCTION",
+            help="Triggers setting weights immediately. NOT RECOMMENDED FOR PRODUCTION. This is used internally by SN21 devs for faster testing.",
         )
         parser.add_argument(
             "--offline",

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -641,7 +641,7 @@ class Validator:
                 weights_report = {"weights": {}}
                 for uid, score in enumerate(self.weights):
                     weights_report["weights"][uid] = score
-                bt.logging.debug("weights_report", weights=weights_report)
+                bt.logging.debug(weights_report)
             except Exception as e:
                 bt.logging.error(f"failed to set weights {e}")
             ws, ui = self.weights.topk(len(self.weights))

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -688,8 +688,9 @@ class Validator:
                     bt.logging.error(f"Failed to set weights after {ttl} seconds")
             else:
                 bt.logging.debug(f"Skipping setting weights. Only set weights at 20-minute marks.")
-                # sleep for 1 minute before checking again
-                time.sleep(60)
+
+            # sleep for 1 minute before checking again
+            time.sleep(60)
 
 
     async def try_sync_metagraph(self, ttl: int):


### PR DESCRIPTION
Puts weight setting in a background task that happens on the 20 minute mark. This synchronizes when validators set weights so hopefully they're in more consensus and vtrust improves.

Also puts in a function that interpolates between the current weight and the normalized consensus weights so that the vtrust does not fall below vturst_min, assuming the consensus does not change. -- borrowed this from Dippy after consulting with their dev team.